### PR TITLE
(maint) The locked version of the oapi dep breaks the build

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,7 +20,7 @@ attrs~=21.2.0
 
 pyjwt==2.0.1
 
-openapi-python-client~=0.10.3
+openapi-python-client
 requests==2.25.1
 
 mmh3


### PR DESCRIPTION
Currently the build fails due to dep mis-matches.
This change removes the specific version and allows pip to
work it out.