### PR TITLE
Issue passing attributes to target

### DIFF
--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -107,7 +107,7 @@ class AnalyticsService(object):
                 if event.target is not None and not event.target.anonymous:
                     target_attributes: List[KeyValue] = []
                     if not isinstance(event.target.attributes, Unset):
-                        for key, value in event.target.attributes:
+                        for key, value in event.target.attributes.items():
                             target_attributes.append(KeyValue(key, value))
                     target_name = event.target.identifier
                     if event.target.name:


### PR DESCRIPTION
Error in FFM-2918:

`Exception in thread Thread-8:
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/user/PycharmProjects/ff_api_example/venv/lib/python3.8/site-packages/featureflags/analytics.py", line 95, in _sync
    self._send_data()
  File "/Users/user/PycharmProjects/ff_api_example/venv/lib/python3.8/site-packages/featureflags/analytics.py", line 110, in _send_data
    for key, value in event.target.attributes:
ValueError: too many values to unpack (expected 2)`