### PR TITLE
[FFM-3685]: Add method to set poll interval, enforce minimum poll time of 60s

### DIFF
--- a/featureflags/config.py
+++ b/featureflags/config.py
@@ -16,16 +16,16 @@ EVENTS_SYNC_INTERVAL = 1 * MINUTE
 
 class Config(object):
     def __init__(
-        self,
-        base_url: str = BASE_URL,
-        events_url: str = EVENTS_URL,
-        pull_interval: int = PULL_INTERVAL,
-        persist_interval: int = PERSIST_INTERVAL,
-        events_sync_interval: int = EVENTS_SYNC_INTERVAL,
-        cache: Cache = None,
-        store: object = None,
-        enable_stream: bool = True,
-        enable_analytics: bool = True
+            self,
+            base_url: str = BASE_URL,
+            events_url: str = EVENTS_URL,
+            pull_interval: int = PULL_INTERVAL,
+            persist_interval: int = PERSIST_INTERVAL,
+            events_sync_interval: int = EVENTS_SYNC_INTERVAL,
+            cache: Cache = None,
+            store: object = None,
+            enable_stream: bool = True,
+            enable_analytics: bool = True
     ):
         self.base_url = base_url
         self.events_url = events_url
@@ -67,5 +67,12 @@ def with_stream_enabled(value: bool) -> Callable:
 def with_analytics_enabled(value: bool) -> Callable:
     def func(config: Config) -> None:
         config.enable_analytics = value
+
+    return func
+
+
+def with_pull_interval(value: int) -> Callable:
+    def func(config: Config) -> None:
+        config.pull_interval = value
 
     return func

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -29,8 +29,9 @@ class PollingProcessor(Thread):
     def run(self):
         if not self.__running:
             if self.__config.pull_interval < 60:
-                log.info("Pull Interval must be greater than or equal to 60 seconds, was: " + str(
-                    self.__config.pull_interval) + " setting to 60")
+                log.info("Pull Interval must be greater than or equal "
+                         "to 60 seconds, was: " +
+                         str(self.__config.pull_interval) + " setting to 60")
                 self.__config.pull_interval = 60
             log.info("Starting PollingProcessor with request interval: " +
                      str(self.__config.pull_interval))

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -30,8 +30,9 @@ class PollingProcessor(Thread):
         if not self.__running:
             if self.__config.pull_interval < 60:
                 log.warning("Pull Interval must be greater than or equal "
-                         "to 60 seconds, was: " +
-                         str(self.__config.pull_interval) + " setting to 60")
+                            "to 60 seconds, was: " +
+                            str(self.__config.pull_interval) +
+                            " setting to 60")
                 self.__config.pull_interval = 60
             log.info("Starting PollingProcessor with request interval: " +
                      str(self.__config.pull_interval))

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -28,6 +28,10 @@ class PollingProcessor(Thread):
 
     def run(self):
         if not self.__running:
+            if self.__config.pull_interval < 60:
+                log.info("Pull Interval must be greater than or equal to 60 seconds, was: " + str(
+                    self.__config.pull_interval) + " setting to 60")
+                self.__config.pull_interval = 60
             log.info("Starting PollingProcessor with request interval: " +
                      str(self.__config.pull_interval))
             self.__running = True

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -29,7 +29,7 @@ class PollingProcessor(Thread):
     def run(self):
         if not self.__running:
             if self.__config.pull_interval < 60:
-                log.info("Pull Interval must be greater than or equal "
+                log.warning("Pull Interval must be greater than or equal "
                          "to 60 seconds, was: " +
                          str(self.__config.pull_interval) + " setting to 60")
                 self.__config.pull_interval = 60


### PR DESCRIPTION
**What has changed**
Adds method 'with_pull_interval' - this is in line with other sdks - currently updating config and setting pull interval was not changing time
Adds minimum pull interval time of 60 seconds (this would never have been less than 60s because it was never changing before hand)

**Behaviour**
not calling with_pull_interval - defaults to 60 seconds
with_pull_interval(60 or greater) -> sets pull interval to specified time
with_pull_interval(less than 60) -> logs that pull level must be 60+ then sets pull interval to default 60s 