### PR TITLE
[FFM-3689]: Add Check to see if analytics are enabled before trying to enqueue them

### DIFF
--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -23,7 +23,7 @@ VERSION: str = "1.0"
 
 class CfClient(object):
     def __init__(
-        self, sdk_key: str, *options: Callable, config: Optional[Config] = None
+            self, sdk_key: str, *options: Callable, config: Optional[Config] = None
     ):
         self._client: Optional[Client] = None
         self._auth_token: Optional[str] = None
@@ -97,7 +97,7 @@ class CfClient(object):
         self._auth_token = response.auth_token
 
         decoded = decode(self._auth_token, options={
-                         "verify_signature": False})
+            "verify_signature": False})
         self._environment_id = decoded["environment"]
         self._cluster = decoded["clusterIdentifier"]
         if not self._cluster:
@@ -115,33 +115,38 @@ class CfClient(object):
     def bool_variation(self, identifier: str, target: Target,
                        default: bool) -> bool:
         variation = self._evaluator.evaluate(identifier, target)
-        self._analytics.enqueue(target, identifier, variation)
+        if self._config.enable_analytics:
+            self._analytics.enqueue(target, identifier, variation)
         return variation.bool(default)
 
     def int_variation(self, identifier: str, target: Target,
                       default: int) -> int:
         variation = self._evaluator.evaluate(identifier, target)
-        self._analytics.enqueue(target, identifier, variation)
+        if self._config.enable_analytics:
+            self._analytics.enqueue(target, identifier, variation)
         return variation.int(default)
 
     def number_variation(self, identifier: str, target: Target,
                          default: float) -> float:
         variation = self._evaluator.evaluate(
             identifier, target)
-        self._analytics.enqueue(target, identifier, variation)
+        if self._config.enable_analytics:
+            self._analytics.enqueue(target, identifier, variation)
         return variation.number(default)
 
     def string_variation(self, identifier: str, target: Target,
                          default: str) -> str:
         variation = self._evaluator.evaluate(
             identifier, target)
-        self._analytics.enqueue(target, identifier, variation)
+        if self._config.enable_analytics:
+            self._analytics.enqueue(target, identifier, variation)
         return variation.string(default)
 
     def json_variation(self, identifier: str, target: Target,
                        default: Dict[str, Any]) -> Dict[str, Any]:
         variation = self._evaluator.evaluate(identifier, target)
-        self._analytics.enqueue(target, identifier, variation)
+        if self._config.enable_analytics:
+            self._analytics.enqueue(target, identifier, variation)
         return variation.json(default)
 
     def close(self):

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -23,7 +23,9 @@ VERSION: str = "1.0"
 
 class CfClient(object):
     def __init__(
-            self, sdk_key: str, *options: Callable, config: Optional[Config] = None
+            self, sdk_key: str,
+            *options: Callable,
+            config: Optional[Config] = None
     ):
         self._client: Optional[Client] = None
         self._auth_token: Optional[str] = None


### PR DESCRIPTION
**What has changed**
Adds check on the variation methods for each type before we try to enqueue analytics

**Behaviour**
Currently:
with analytics as false we get an exception saying every time we poll for a flag
`AttributeError: 'CfClient' object has no attribute '_analytics'`

After change:
We do not hit the code to send analytics because it is false and won't exist