### PR TITLE
[SWAT-8089]: Python SDK doesnt update cache after segment change event

### DIFF
--- a/featureflags/repository.py
+++ b/featureflags/repository.py
@@ -210,7 +210,7 @@ class Repository(DataProviderInterface):
         if segment and not isinstance(segment.version, Unset) and \
                 not isinstance(new_segment, Unset) and \
                 not isinstance(new_segment.version, Unset):
-            return segment.version >= segment.version
+            return segment.version >= new_segment.version
         return False
 
 


### PR DESCRIPTION
with the new segment, but it was comparing the version from the same object so it
always failed.

  This meant that data might not be evaluted correctly until the SDK
  restarts.