### PR TITLE
FFM-3667 - Remove type check on pre req check as MV flags do not evaluate correctly

### DIFF
--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -293,7 +293,8 @@ class Evaluator(object):
                 log.info('Pre requisite flag %s should have the variations %s',
                          config.feature, pqs.variations)
 
-                if variation.identifier not in pqs.variations:
+                if not isinstance(variation, Unset) and variation.identifier \
+                        not in pqs.variations:
                     return False
                 else:
                     return self._check_prerequisite(config, target)

--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -293,8 +293,7 @@ class Evaluator(object):
                 log.info('Pre requisite flag %s should have the variations %s',
                          config.feature, pqs.variations)
 
-                if isinstance(variation, Unset) and variation.identifier \
-                        not in pqs.variations:
+                if variation.identifier not in pqs.variations:
                     return False
                 else:
                     return self._check_prerequisite(config, target)


### PR DESCRIPTION
**What**
[FFM-3868](https://harness.atlassian.net/browse/FFM-3868)
Remove type check on pre requisites check so MV Flags evaluate correctly

**Why**
When a pre req is not a boolean flag we don't evaluate correctly. This can cause behaviour where once turned on, flags with prereqs cannot be turned off, regardless of the pre req state

**Testing**
Manually tested MV and Bool scenarios, flags evaluating correctly
