### PR TITLE
[FFM-5263]: Fix pre-req evaluations

### DIFF
--- a/featureflags/evaluations/clause.py
+++ b/featureflags/evaluations/clause.py
@@ -77,7 +77,8 @@ class Clause(object):
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        id = d.pop("id")
+        # If clause ID is missing, then default to empty
+        id = d.pop("id", "")
 
         attribute = d.pop("attribute")
 

--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -22,7 +22,6 @@ from featureflags.models.unset import Unset
 from featureflags.repository import QueryInterface
 from featureflags.util import log
 
-
 EMPTY_VARIATION = Variation(identifier="", value=None)
 
 
@@ -114,7 +113,7 @@ class Evaluator(object):
 
                 # Should Target be included via segment rules
                 if segment.rules and self._evaluate_clauses(segment.rules,
-                                                            target):
+                                                                  target):
                     log.debug('Target %s included in segment %s via rules\n',
                               target.name, segment.name)
                     return True
@@ -221,9 +220,9 @@ class Evaluator(object):
 
         for variation_map in var_target_map:
             if not isinstance(variation_map.targets, Unset) and next(
-                (val for val in variation_map.targets
-                    if not isinstance(val, Unset) and val.identifier ==
-                 target.identifier), None) is not None:
+                    (val for val in variation_map.targets
+                     if not isinstance(val, Unset) and val.identifier ==
+                        target.identifier), None) is not None:
                 log.debug("Evaluate variation map with result %s",
                           variation_map.variation)
                 return variation_map.variation
@@ -293,7 +292,7 @@ class Evaluator(object):
                 log.info('Pre requisite flag %s should have the variations %s',
                          config.feature, pqs.variations)
 
-                if not isinstance(variation, Unset) and variation.identifier \
+                if isinstance(variation, Unset) or variation.identifier \
                         not in pqs.variations:
                     return False
                 else:

--- a/featureflags/evaluations/segment.py
+++ b/featureflags/evaluations/segment.py
@@ -109,10 +109,17 @@ class Segment(object):
 
             tags.append(tags_item)
 
-        included = [Target.from_dict(target)
-                    for target in d.pop("included", UNSET)]
-        excluded = [Target.from_dict(target)
-                    for target in d.pop("excluded", UNSET)]
+        # If included list is present and not empty, then extract the values
+        included = []
+        if "included" in d and d["included"]:
+            included = [Target.from_dict(target)
+                        for target in d.pop("included", UNSET)]
+
+        # If excluded list is present and not empty, then extract the values
+        excluded = []
+        if "excluded" in d and d["excluded"]:
+            excluded = [Target.from_dict(target)
+                        for target in d.pop("excluded", UNSET)]
 
         rules: Clauses = Clauses()
         _rules = d.pop("rules", UNSET)

--- a/tests/integration/test_evaluator.py
+++ b/tests/integration/test_evaluator.py
@@ -1,4 +1,3 @@
-
 import pytest
 import json
 import os
@@ -12,10 +11,8 @@ from featureflags.lru_cache import LRUCache
 from featureflags.repository import Repository
 from featureflags.evaluations.evaluator import Evaluator
 
-
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 PATH = cwd = BASE_PATH + "/ff-test-cases/tests/"
-
 
 cache = LRUCache()
 repository = Repository(cache)
@@ -23,41 +20,68 @@ evaluator = Evaluator(repository)
 
 
 @define
-class Usecase:
-    flag: FeatureConfig
-    segments: List[Segment]
-    targets: List[Target]
-    expected: Dict[str, Any]
+class Test:
+    flag: str
+    target: str
+    expected: Any
 
     @classmethod
-    def from_dict(cls, source: Dict[str, Any]) -> 'Usecase':
-        flag = FeatureConfig.from_dict(source["flag"])
+    def from_dict(cls, source: Dict[str, Any]) -> 'Test':
+        return Test(source["flag"], source.get("target", "default"),
+                    source["expected"])
+
+
+@define
+class Feature:
+    flags: List[FeatureConfig]
+    segments: List[Segment]
+    targets: List[Target]
+    tests: List[Test]
+
+    @classmethod
+    def from_dict(cls, source: Dict[str, Any]) -> 'Feature':
+        flags = [FeatureConfig.from_dict(flag) for flag in source["flags"]]
 
         segments = []
         if "segments" in source:
             segments = [Segment.from_dict(segment)
                         for segment in source["segments"]]
-        targets = [Target.from_dict(target) for target in source["targets"]]
-        expected = source["expected"]
-        return Usecase(flag=flag, segments=segments, targets=targets,
-                       expected=expected)
+        targets = []
+        if "targets" in source:
+            targets = [Target.from_dict(target) for target in source["targets"]]
+
+        tests = [Test.from_dict(test) for test in source["tests"]]
+
+        return Feature(flags=flags, segments=segments, targets=targets,
+                       tests=tests)
 
 
-def load_json_test_file(filename: str) -> Usecase:
+@define
+class TestCase:
+    name: str
+    flag: str
+    target: str
+    expected: str
+    targets: List[Target]
+
+
+def load_json_test_file(filename: str) -> Feature:
     result = None
     with open(filename, 'r') as f:
-        result = Usecase.from_dict(json.load(f))
+        result = Feature.from_dict(json.load(f))
     return result
 
 
 def load_test_files():
     result = []
-    for file in os.listdir(PATH):
-        if file.endswith(".json"):
-            fname = os.path.join(PATH, file)
-            usecase = load_json_test_file(fname)
-            usecase.flag.feature += file
-            result.append((fname, usecase))
+    for r, d, f in os.walk(PATH):
+        for file in f:
+            if '.json' in file:
+                fname = os.path.join(r, file)
+                print(f'Loading File: {fname}.')
+                usecase = load_json_test_file(fname)
+                # usecase.flag.feature += file
+                result.append((fname, usecase))
     return result
 
 
@@ -66,24 +90,36 @@ def usecase_provider():
 
     result = []
     for fname, usecase in usecases:
-        repository.set_flag(usecase.flag)
+        for flag in usecase.flags:
+            repository.set_flag(flag)
 
         for segment in usecase.segments:
             repository.set_segment(segment)
 
-        for identifier, value in usecase.expected.items():
-            result.append((fname, identifier, value, usecase))
+        for test_case in usecase.tests:
+            result.append(
+                TestCase(name='given flag {} then target {} should get {}'
+                         .format(test_case.flag,
+                                 test_case.target,
+                                 test_case.expected),
+                         flag=test_case.flag,
+                         target=test_case.target,
+                         expected=test_case.expected,
+                         targets=usecase.targets))
 
     return result
 
 
-@pytest.mark.parametrize('fname,identifier,expected,usecase',
-                         usecase_provider())
-def test_evaluator(fname, identifier, expected, usecase):
+def feature_name(tc):
+    return tc.name
+
+
+@pytest.mark.parametrize('tc', usecase_provider(), ids=feature_name)
+def test_evaluator(tc: TestCase):
     target = None
-    if identifier != "_no_target":
+    if tc.target != "_no_target":
         target = next(
-            (val for val in usecase.targets if val.identifier == identifier),
+            (val for val in tc.targets if val.identifier == tc.target),
             None
         )
 
@@ -91,17 +127,20 @@ def test_evaluator(fname, identifier, expected, usecase):
 
     switch_kind = {
         FeatureConfigKind.BOOLEAN:
-            lambda: evaluator.evaluate(usecase.flag.feature, target).bool(),
+            lambda: evaluator.evaluate(tc.flag, target).bool(default=False),
         FeatureConfigKind.STRING:
-            lambda: evaluator.evaluate(usecase.flag.feature, target).string(),
+            lambda: evaluator.evaluate(tc.flag, target).string(
+                default="failed"),
         FeatureConfigKind.INT:
-            lambda: evaluator.evaluate(usecase.flag.feature, target).int(),
-        FeatureConfigKind.NUMBER:
-            lambda: evaluator.evaluate(usecase.flag.feature, target).number(),
+            lambda: evaluator.evaluate(tc.flag, target).number(default=0.100),
         FeatureConfigKind.JSON:
-            lambda: evaluator.evaluate(usecase.flag.feature, target).json(),
+            lambda: evaluator.evaluate(tc.flag, target).json(default={}),
     }
 
-    got = switch_kind[usecase.flag.kind]()
+    kind = repository.get_flag(tc.flag).kind
+    got = switch_kind[kind]()
 
-    assert got == expected
+    if kind == FeatureConfigKind.JSON:
+        tc.expected = json.loads(tc.expected)
+
+    assert got == tc.expected


### PR DESCRIPTION
This change fixes an issue with the pre-req evaluations, where the evaluator was AND'ing if the variation was valid and not present.

Updated the evalutor tests to use the latest ff-test-cases