### PR TITLE
FFM-5955 - Store Unique Targets 

### DIFF
--- a/examples/bool_variation_example/bool_variation.py
+++ b/examples/bool_variation_example/bool_variation.py
@@ -4,6 +4,7 @@ from featureflags.evaluations.auth_target import Target
 from featureflags.client import CfClient
 from featureflags.util import log
 
+## TODO - undo this file
 def main():
     log.debug("Starting example")
     api_key = "545535fb-43c0-448d-b57f-498c378c7a80"

--- a/examples/bool_variation_example/bool_variation.py
+++ b/examples/bool_variation_example/bool_variation.py
@@ -6,13 +6,21 @@ from featureflags.util import log
 
 def main():
     log.debug("Starting example")
-    api_key = "Your API Key"
+    api_key = "545535fb-43c0-448d-b57f-498c378c7a80"
     client = CfClient(api_key)
 
-    target = Target(identifier='harness')
-
+    target = Target(identifier='2')
+    target2 = Target(identifier='3')
+    target3 = Target(identifier='4')
+    target4 = Target(identifier='5')
     while True:
-        result = client.bool_variation('identifier_of_your_bool_flag', target, False)
+        result = client.bool_variation('flag1', target, False)
+        log.debug("Result %s", result)
+        result = client.bool_variation('flag1', target2, False)
+        log.debug("Result %s", result)
+        result = client.bool_variation('flag1', target3, False)
+        log.debug("Result %s", result)
+        result = client.bool_variation('flag1', target4, False)
         log.debug("Result %s", result)
         time.sleep(10)
 

--- a/examples/bool_variation_example/bool_variation.py
+++ b/examples/bool_variation_example/bool_variation.py
@@ -10,10 +10,10 @@ def main():
     api_key = "545535fb-43c0-448d-b57f-498c378c7a80"
     client = CfClient(api_key)
 
-    target = Target(identifier='2')
-    target2 = Target(identifier='3')
-    target3 = Target(identifier='4')
-    target4 = Target(identifier='5')
+    target = Target(identifier='2', attributes={"email": "demo@harness.io"})
+    target2 = Target(identifier='3', attributes={"email": "demo@harness.io"})
+    target3 = Target(identifier='4', attributes={"email": "demo@harness.io"})
+    target4 = Target(identifier='5', attributes={"email": "demo@harness.io"})
     while True:
         result = client.bool_variation('flag1', target, False)
         log.debug("Result %s", result)

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -24,7 +24,7 @@ FF_METRIC_TYPE = 'FFMETRICS'
 FEATURE_IDENTIFIER_ATTRIBUTE = 'featureIdentifier'
 FEATURE_NAME_ATTRIBUTE = 'featureName'
 VARIATION_IDENTIFIER_ATTRIBUTE = 'variationIdentifier'
-VARIATION_VALUE_ATTRIBUTE = 'featureValue'
+VARIATION_VALUE_ATTRIBUTE = 'variationValue'
 TARGET_ATTRIBUTE = 'target'
 SDK_VERSION_ATTRIBUTE = 'SDK_VERSION'
 SDK_VERSION = '1.0.0'
@@ -167,6 +167,7 @@ class AnalyticsService(object):
                 target_data.append(td)
         finally:
             self._data = {}
+            self._target_data = {}
             self._lock.release()
         body: Metrics = Metrics(target_data=target_data,
                                 metrics_data=metrics_data)

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -74,7 +74,7 @@ class AnalyticsService(object):
 
         self._lock.acquire()
         try:
-            # Store unique evaluation events
+            # Store unique evaluation events. We map a unique evaluation event to its count.
             unique_evaluation_key = self.get_key(event)
             if unique_evaluation_key in self._data:
                 self._data[unique_evaluation_key].count += 1
@@ -82,7 +82,7 @@ class AnalyticsService(object):
                 event.count = 1
                 self._data[unique_evaluation_key] = event
 
-            # Store unique targets
+            # Store unique targets. If the target already exists just ignore it.
             unique_target_key = self.get_target_key(event)
             if unique_target_key not in self._target_data:
                 target_name = event.target.name

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -154,18 +154,14 @@ class AnalyticsService(object):
                     attributes=metric_attributes
                 )
                 metrics_data.append(md)
-            for _, unique_target in self._target_data:
+            for _, unique_target in self._target_data.items():
                 target_attributes: List[KeyValue] = []
-                if not isinstance(event.target.attributes, Unset):
-                    for key, value in event.target.attributes.items():
+                if not isinstance(unique_target.attributes, Unset):
+                    for key, value in unique_target.attributes.items():
                         target_attributes.append(KeyValue(key, value))
-                target_name = event.target.identifier
-                if event.target.name:
-                    target_name = event.target.name
-
                 td = TargetData(
-                    identifier=event.target.identifier,
-                    name=target_name,
+                    identifier=unique_target.identifier,
+                    name=unique_target.name,
                     attributes=target_attributes
                 )
                 target_data.append(td)


### PR DESCRIPTION
# What 

For a given metrics interval, we were only storing targets for each unique evaluation event. That meant if there were two different targets requesting evaluations for the same flag, but they resulted in the same variation, only the first target would get stored. This change stores unique targets in the same class, but in a separate instance variable. 

# Why
So we can register all unique targets for a given metrics interval

# Testing
I have tested this manually using prod-2. 
- sent 4 different targets in the same interval - all were registered
- sent 3 different targets and one duplicate (only three were stored and in the final request) 
- new target data instance variable gets cleared at the end of each metrics interval