### PR TITLE
FFM-6158 Convert non-string attribute values to string

### DIFF
--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.1.5'
+__version__ = '1.1.6'

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -160,7 +160,8 @@ class AnalyticsService(object):
                 target_attributes: List[KeyValue] = []
                 if not isinstance(unique_target.attributes, Unset):
                     for key, value in unique_target.attributes.items():
-                        target_attributes.append(KeyValue(key, value))
+                        # Attribute values need to be sent as string to ff-server to convert all values to strings.
+                        target_attributes.append(KeyValue(key, str(value)))
                 td = TargetData(
                     identifier=unique_target.identifier,
                     name=unique_target.name,

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -160,7 +160,8 @@ class AnalyticsService(object):
                 target_attributes: List[KeyValue] = []
                 if not isinstance(unique_target.attributes, Unset):
                     for key, value in unique_target.attributes.items():
-                        # Attribute values need to be sent as string to ff-server to convert all values to strings.
+                        # Attribute values need to be sent as string to
+                        # ff-server so convert all values to strings.
                         target_attributes.append(KeyValue(key, str(value)))
                 td = TargetData(
                     identifier=unique_target.identifier,

--- a/featureflags/evaluations/auth_target.py
+++ b/featureflags/evaluations/auth_target.py
@@ -16,7 +16,7 @@ class Target():
     identifier: str
     name: Union[Unset, str] = UNSET
     anonymous: Union[Unset, bool] = UNSET
-    attributes: Union[Unset, Dict[str, Any]] = UNSET
+    attributes: Union[Unset, Dict[str, str]] = UNSET
 
     def to_dict(self) -> Dict[str, Any]:
         identifier = self.identifier

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.5
+current_version = 1.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/harness/ff-python-server-sdk",
-    version='1.1.5',
+    version='1.1.6',
     zip_safe=False,
 )


### PR DESCRIPTION
# What

The SDK did not check or convert non-string attribute values to string, which resulted in 500 errors from the metrics service. This change solves that by:

1. A type check so that if any constant non-string values are provided they’ll get caught by static analysis in your IDE
2. A runtime check which converts non-string values to String.

# Why
So the SDK posts valid target data 

# Testing 
Tested with the following Targets. All were registered with correct attributes and flag evaluation events were registered as well.

    target = Target(identifier='erdi1', attributes={"email": 123})
    target2 = Target(identifier='erdi2', attributes={"email": {"hello": "hello"}})
    target3 = Target(identifier='erdi3', attributes={"email": [123, "123", True, {"Hello": 123}, {"Hello": "123"}]})
    target4 = Target(identifier='erdi4', attributes={"email": True})