### PR TITLE
FFM-6158 Remove static check

### DIFF
--- a/featureflags/evaluations/auth_target.py
+++ b/featureflags/evaluations/auth_target.py
@@ -16,7 +16,7 @@ class Target():
     identifier: str
     name: Union[Unset, str] = UNSET
     anonymous: Union[Unset, bool] = UNSET
-    attributes: Union[Unset, Dict[str, str]] = UNSET
+    attributes: Union[Unset, Dict[str, Any]] = UNSET
 
     def to_dict(self) -> Dict[str, Any]:
         identifier = self.identifier


### PR DESCRIPTION
# What

Changing attributes type from any to string didn't make sense, as we accept non-string values. This will remove the warning if users use non-string attribute values.