### PR TITLE
FFM-5991 Make IN operator case sensitive

### DIFF
--- a/featureflags/ftypes/string.py
+++ b/featureflags/ftypes/string.py
@@ -54,4 +54,4 @@ class String(Interface):
         return self.value.lower() <= _value.lower()
 
     def in_list(self, value: typing.List[typing.Any]) -> bool:
-        return self.value.lower() in (val.lower() for val in value)
+        return self.value in value

--- a/tests/unit/test_string.py
+++ b/tests/unit/test_string.py
@@ -20,7 +20,6 @@ from featureflags.ftypes.string import String
     ],
 )
 def test_type_methods(mocker, arg, input, mocked, method, expected):
-
     m = mocker.patch("featureflags.ftypes.string.get_str_value",
                      return_value=mocked)
     _string = String(value=arg)
@@ -33,11 +32,19 @@ def test_type_methods(mocker, arg, input, mocked, method, expected):
         m.assert_called_with(input)
 
 
-def test_in_list():
+def test_in_list_match():
+    _string = String(value="Harness")
 
-    _string = String(value="harness")
+    got = _string.in_list(["wings", "Harness"])
+    expected = True
+
+    assert got == expected
+
+
+def test_in_list_no_match():
+    _string = String(value="Harness")
 
     got = _string.in_list(["wings", "harness"])
-    expected = True
+    expected = False
 
     assert got == expected


### PR DESCRIPTION
# What
The `in` operator was lower casing the values to be compared. All operators are case sensitive apart from `equals_insensitive` so this change removes that behaviour.

# Testing
TestGrid
 - Failing scenarios now passing
 - No regression on other scenarios
 
Unit tests updated