### PR TITLE
FFM-6549 Add wait_for_initialization functionality

### DIFF
--- a/examples/wait_for_initialization_example/wait_for_initialization.py
+++ b/examples/wait_for_initialization_example/wait_for_initialization.py
@@ -1,0 +1,28 @@
+import time
+
+from featureflags.config import with_base_url, with_events_url
+from featureflags.evaluations.auth_target import Target
+from featureflags.client import CfClient
+from featureflags.util import log
+
+
+def main():
+    log.debug("Starting example")
+    api_key = "Your API Key"
+    client = CfClient(api_key)
+    # Don't continue until all flags and groups have been loaded into the cache.
+    log.debug("Waiting to load all flags and groups before proceeding")
+    client.wait_for_initialization()
+
+    #  If required you can check the initialized status of the Client at anytime
+    log.debug("Client is_initialized status is %s", client.is_initialized())
+    target = Target(identifier='harness')
+
+    while True:
+        result = client.bool_variation('identifier_of_your_bool_flag', target, False)
+        log.debug("Result %s", result)
+        time.sleep(10)
+
+
+if __name__ == "__main__":
+    main()

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -28,6 +28,7 @@ class CfClient(object):
             config: Optional[Config] = None
     ):
         self._client: Optional[Client] = None
+        #  The Client is considered initialized when flags and groups are loaded into cache.
         self._initialized = threading.Event()
         self._auth_token: Optional[str] = None
         self._environment_id: Optional[str] = None
@@ -48,8 +49,8 @@ class CfClient(object):
         self._repository = Repository(self._config.cache)
         self._evaluator = Evaluator(self._repository)
 
-        log.debug("CfClient initialized")
         self.run()
+        log.debug("CfClient initialized")
 
     def run(self):
         self.authenticate()
@@ -61,6 +62,9 @@ class CfClient(object):
             client=self._client,
             config=self._config,
             environment_id=self._environment_id,
+            #  PollingProcessor is responsible for doing the initial flag/group fetch and cache. So we allocate it
+            #  the responsibility for setting the Client is_initialized variable.
+            wait_for_initialization=self._initialized,
             ready=polling_event,
             stream_ready=streaming_event,
             repository=self._repository
@@ -90,6 +94,9 @@ class CfClient(object):
 
     def wait_for_initialization(self):
         self._initialized.wait()
+
+    def is_initialized(self):
+        return self._initialized.is_set()
 
     def get_environment_id(self):
         return self._environment_id

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -28,6 +28,7 @@ class CfClient(object):
             config: Optional[Config] = None
     ):
         self._client: Optional[Client] = None
+        self._initialized = threading.Event()
         self._auth_token: Optional[str] = None
         self._environment_id: Optional[str] = None
         self._sdk_key: Optional[str] = sdk_key
@@ -86,6 +87,9 @@ class CfClient(object):
                 client=self._client,
                 environment=self._environment_id
             )
+
+    def wait_for_initialization(self):
+        self._initialized.wait()
 
     def get_environment_id(self):
         return self._environment_id

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -13,7 +13,7 @@ from .util import log
 class PollingProcessor(Thread):
 
     def __init__(self, client: AuthenticatedClient, config: Config,
-                 environment_id: str, ready: Event,
+                 environment_id: str, flags_and_groups_cached: Event, ready: Event,
                  stream_ready: Event,
                  repository: DataProviderInterface) -> None:
         Thread.__init__(self)
@@ -22,6 +22,7 @@ class PollingProcessor(Thread):
         self.__client = client
         self.__config = config
         self.__running = False
+        self.__flags_and_groups_cached = flags_and_groups_cached
         self.__ready = ready
         self.__stream_ready = stream_ready
         self.__repository = repository


### PR DESCRIPTION
# What
Adds method which can be called which will block until all flags and groups have been loaded into cache. Also adds method to check the initialization status on demand.

# Testing 
Manual. QA account with 500 + flags