### PR TITLE
FFM-6932 - SDK seems to disconnect from the relay proxy

### DIFF
--- a/examples/getting_started/getting_started.py
+++ b/examples/getting_started/getting_started.py
@@ -24,7 +24,7 @@ def main():
     # Loop forever reporting the state of the flag
     while True:
         result = client.bool_variation(flagName, target, False)
-        log.info("Flag variation %s", result)
+        log.info("%s flag variation %s", flagName, result)
         time.sleep(10)
            
     close()

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -65,6 +65,7 @@ class PollingProcessor(Thread):
                             self.__stream_ready.is_set():
                         log.debug('Poller will be paused because' +
                                   ' streaming mode is active')
+                        self.retrieve_flags_and_segments()  # on stream disconnect, make sure flags are in sync before pausing
                         #  Block until ready.set() is called
                         self.__ready.wait()
                         log.debug('Poller resuming ')

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -48,6 +48,9 @@ class SSEClient(object):
         # The 'Accept' header is not required, but explicit > implicit
         self.requests_kwargs["headers"]["Accept"] = "text/event-stream"
 
+        # If we haven't gotten any heartbeats from the server in 60 seconds, then we assume the socket has died
+        self.requests_kwargs["timeout"] = 60
+
         # Keep data here as it streams in
         self.buf: str = ""
 


### PR DESCRIPTION
FFM-6932 - SDK seems to disconnect from the relay proxy

What
Add timeout parameter of 60 seconds to HTTP request to force socket to time out if no data arrives. The timeout will trigger an exception so that the poller is restarted. Also before putting the poller to sleep when stream is enabled, make sure we retrieve the flags.

Why
Customers are reporting SSE updates stopping and flags getting out of date

Testing
Manual - ensured that after connection was lost to SSE stream that the poller is restarted