### PR TITLE
FFM-7504: Fix uncaught exception in poll processor

### DIFF
--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -54,6 +54,8 @@ class PollingProcessor(Thread):
                     'getting initial flags and segments. %s',
                     ex
                 )
+                raise
+
             #  Sleep for an interval before going into the polling loop.
             time.sleep(self.__config.pull_interval)
             log.info("Starting PollingProcessor with request interval: " +
@@ -78,6 +80,7 @@ class PollingProcessor(Thread):
                         'Error: Exception encountered when polling flags. %s',
                         e
                     )
+                    raise
 
                 elapsed = time.time() - start_time
                 if elapsed < self.__config.pull_interval:


### PR DESCRIPTION
When trying to retrieve flags and segments in Poll processor, there is an uncaught exception, which doesn't get logged until the thread dies. This fix catches the exception and raises it upward so user can handle it in their code.