### PR TITLE
FFM-6410 Evaluate multiple and nested prerequisites correctly

### DIFF
--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.1.10'
+__version__ = '1.1.11'

--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -295,6 +295,7 @@ class Evaluator(object):
                 if isinstance(variation, Unset) or variation.identifier \
                         not in pqs.variations:
                     return False
+                # Check for any nested prerequisites 
                 elif not self._check_prerequisite(config, target):
                     return False
         return True

--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -295,8 +295,8 @@ class Evaluator(object):
                 if isinstance(variation, Unset) or variation.identifier \
                         not in pqs.variations:
                     return False
-                else:
-                    return self._check_prerequisite(config, target)
+                elif not self._check_prerequisite(config, target):
+                    return False
         return True
 
     def evaluate(self, identifier: str, target: Target) -> Variation:

--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -295,8 +295,8 @@ class Evaluator(object):
                 if isinstance(variation, Unset) or variation.identifier \
                         not in pqs.variations:
                     return False
-                # Check for any nested prerequisites 
-                elif not self._check_prerequisite(config, target):
+                # Check for any nested prerequisites
+                if not self._check_prerequisite(config, target):
                     return False
         return True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.10
+current_version = 1.1.11
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/harness/ff-python-server-sdk",
-    version='1.1.10',
+    version='1.1.11',
     zip_safe=False,
 )


### PR DESCRIPTION
# What
Error in logic would cause the prerequisite loop to return early. This fix allows multiple prerequisites and any nested prerequisites to be checked.

# Testing
Testgrid + manual:
 - all testgrid scenarios passing  
 - nested prerequisites evaluating correctly in manual check
