### PR TITLE
FFM-7880 Improve SSE Client error logging

### DIFF
--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.1.11'
+__version__ = '1.1.12'

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -110,13 +110,16 @@ class SSEClient(object):
 
             except (StopIteration, requests.RequestException, EOFError) as e:
                 if isinstance(e, StopIteration):
-                    log.error("Error when iterating through stream messages, attempting to resume")
+                    log.error("Error when iterating through stream messages, "
+                              "attempting to resume")
 
                 if isinstance(e, EOFError):
-                    log.error("Received unexpected EOF from stream, attempting to reconnect")
+                    log.error("Received unexpected EOF from stream, "
+                              "attempting to reconnect")
 
                 if isinstance(e, requests.RequestException):
-                    log.error("Error encountered in stream, attempting to reconnect: %s", e)
+                    log.error("Error encountered in stream, "
+                              "attempting to reconnect: %s", e)
 
                 time.sleep(self.retry / 1000.0)
                 self._connect()

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -109,7 +109,15 @@ class SSEClient(object):
                 self.buf += self.decoder.decode(next_chunk)
 
             except (StopIteration, requests.RequestException, EOFError) as e:
-                log.error(e)
+                if isinstance(e, StopIteration):
+                    log.error("Error when iterating through stream messages, attempting to resume")
+
+                if isinstance(e, EOFError):
+                    log.error("Received unexpected EOF from stream, attempting to reconnect")
+
+                if isinstance(e, requests.RequestException):
+                    log.error("Error encountered in stream, attempting to reconnect: %s", e)
+
                 time.sleep(self.retry / 1000.0)
                 self._connect()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.11
+current_version = 1.1.12
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/harness/ff-python-server-sdk",
-    version='1.1.11',
+    version='1.1.12',
     zip_safe=False,
 )


### PR DESCRIPTION
# What
When iterating through a new stream event, we catch three different exceptions. The `StopIteration` exception and `EOFError` have a `value` of `None` which results in an empty string when being logged, resulting in unhelpful error logs. This change adds type checks and logs more approriate statements depending on the error type. 

# Why
To remove blank log statements. 

# Testing
Simulated `StopIteration` errors using the `mocklb` tool in ff-server. I was unable to simulate `EOFError` so just to be on the safe side, I have not logged its value, but tailored a log string for it.