### PR TITLE
FFM-5496 Add SDK Code to failed evaluation 

### DIFF
--- a/featureflags/evaluations/variation.py
+++ b/featureflags/evaluations/variation.py
@@ -34,8 +34,8 @@ class Variation(object):
         if self.value:
             return self.value
         log.error(
-            "SDK_EVAL_6001: Failed to evaluate string variation for %s and the "
-            "default variation '%s' is being returned",
+            "SDK_EVAL_6001: Failed to evaluate string variation for %s and the"
+            " default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default
 
@@ -44,8 +44,8 @@ class Variation(object):
         if self.value:
             return float(self.value)
         log.error(
-            "SDK_EVAL_6001: Failed to evaluate number variation for %s and the "
-            "default variation '%s' is being returned",
+            "SDK_EVAL_6001: Failed to evaluate number variation for %s and the"
+            " default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default
 

--- a/featureflags/evaluations/variation.py
+++ b/featureflags/evaluations/variation.py
@@ -24,7 +24,7 @@ class Variation(object):
         if self.value:
             return self.value.lower() == "true"
         log.error(
-            "Failed to evaluate bool variation for %s and the "
+            "SDK_EVAL_6001: Failed to evaluate bool variation for %s and the "
             "default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default
@@ -34,7 +34,7 @@ class Variation(object):
         if self.value:
             return self.value
         log.error(
-            "Failed to evaluate string variation for %s and the "
+            "SDK_EVAL_6001: Failed to evaluate string variation for %s and the "
             "default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default
@@ -44,7 +44,7 @@ class Variation(object):
         if self.value:
             return float(self.value)
         log.error(
-            "Failed to evaluate number variation for %s and the "
+            "SDK_EVAL_6001: Failed to evaluate number variation for %s and the "
             "default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default
@@ -54,7 +54,7 @@ class Variation(object):
         if self.value:
             return int(self.value)
         log.error(
-            "Failed to evaluate int variation for %s and the "
+            "SDK_EVAL_6001: Failed to evaluate int variation for %s and the "
             "default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default
@@ -64,7 +64,7 @@ class Variation(object):
         if self.value:
             return json.loads(self.value)
         log.error(
-            "Failed to evaluate json variation for %s and the "
+            "SDK_EVAL_6001: Failed to evaluate json variation for %s and the "
             "default variation '%s' is being returned",
             {"target": target.identifier, "flag": flag_identifier}, default)
         return default


### PR DESCRIPTION
# What
The SDK already logged a message if it failed evaluation and had to return the default variation in https://github.com/harness/ff-python-server-sdk/pull/58 - this PR appends the correct SDK code to the log message

# Testing 
Manual - all public xVariation funtions