### PR TITLE
FFM-7177 Authentication Retries

### DIFF
--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -23,6 +23,7 @@ You can pass the configuration in as options when the SDK client is created.
 | enableStream    | with_stream_enabled(True),                               | Enable streaming mode.                                                                                                                           | true                                 |
 | enableAnalytics | with_analytics_enabled(True)                             | Enable analytics.  Metrics data is posted every 60s                                                                                              | true                                 |
 | pollInterval    | with_poll_interval(120)                                  | When running in stream mode, the interval in seconds that we poll for changes.                                                                   | 60                                   |
+| maxAuthRetries  | with_max_auth_retries(10)                                | The number of retry attempts to make if client authentication fails on a retryable HTTP error                                                    | 10                                   |
 
 ## Logging Configuration
 The SDK provides a logger that wraps the standard python logging package.  You can import and use it with:

--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.1.12'
+__version__ = '1.1.13'

--- a/featureflags/api/client.py
+++ b/featureflags/api/client.py
@@ -13,6 +13,7 @@ class Client:
     cookies: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
     headers: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
     timeout: float = attr.ib(5.0, kw_only=True)
+    max_auth_retries: int
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""
@@ -34,6 +35,9 @@ class Client:
 
     def get_timeout(self) -> float:
         return self.timeout
+
+    def get_max_auth_retries(self) -> int:
+        return self.max_auth_retries
 
     def with_timeout(self, timeout: float) -> "Client":
         """

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -85,9 +85,11 @@ def handle_http_result(response):
 def _post_request(kwargs, max_auth_retries):
     retryer = Retrying(
         wait=wait_exponential(multiplier=1, min=4, max=10),
-        retry=(retry_if_result(
-            lambda response: response.status_code != 200
-            and handle_http_result)),
+        retry=(
+            retry_if_result(
+                lambda response: response.status_code != 404)
+            and retry_if_result(handle_http_result)
+        ),
         before_sleep=lambda retry_state: log.warning(
             f'SDK_AUTH_2002: Authentication attempt #'
             f'{retry_state.attempt_number} '

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -91,7 +91,7 @@ def handle_http_result(response):
     # 503 service unavailable
     # 504 gateway timeout
     #  -1 OpenAPI error (timeout etc.)
-    if response.status_code in [404, 425, 429, 500, 502, 503, 504, -1]:
+    if response.status_code in [408, 425, 429, 500, 502, 503, 504, -1]:
         return True
     else:
         return False

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -10,9 +10,9 @@ from tenacity import retry, retry_if_result
 
 
 def _get_kwargs(
-    *,
-    client: Client,
-    json_body: AuthenticationRequest,
+        *,
+        client: Client,
+        json_body: AuthenticationRequest,
 ) -> Dict[str, Any]:
     url = "{}/client/auth".format(client.base_url)
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, response: httpx.Response
+        *, response: httpx.Response
 ) -> Optional[Union[AuthenticationResponse, None]]:
     if response.status_code == 200:
         response_200 = AuthenticationResponse.from_dict(response.json())
@@ -57,7 +57,7 @@ def _parse_response(
 
 
 def _build_response(
-    *, response: httpx.Response
+        *, response: httpx.Response
 ) -> Response[Union[AuthenticationResponse, None]]:
     return Response(
         status_code=response.status_code,
@@ -68,9 +68,9 @@ def _build_response(
 
 
 def sync_detailed(
-    *,
-    client: Client,
-    json_body: AuthenticationRequest,
+        *,
+        client: Client,
+        json_body: AuthenticationRequest,
 ) -> Response[Union[AuthenticationResponse, None]]:
     kwargs = _get_kwargs(
         client=client,
@@ -99,9 +99,11 @@ def handle_http_result(response):
 
 
 # @retry(stop_max_attempt_number=3, retry_on_result=handle_http_result)
-@retry(retry=
-       (retry_if_result(lambda response: response.status_code != 200) and
-        retry_if_result(handle_http_result)))
+@retry(
+    retry=(
+        retry_if_result(lambda response: response.status_code != 200) and
+        retry_if_result(handle_http_result))
+)
 def _post_request(kwargs):
     return httpx.post(
         **kwargs,
@@ -109,9 +111,9 @@ def _post_request(kwargs):
 
 
 def sync(
-    *,
-    client: Client,
-    json_body: AuthenticationRequest,
+        *,
+        client: Client,
+        json_body: AuthenticationRequest,
 ) -> Optional[Union[AuthenticationResponse, None]]:
     """Used to retrieve all target segments for certain account id."""
 
@@ -121,14 +123,10 @@ def sync(
     ).parsed
 
 
-
-
-
-
 async def asyncio_detailed(
-    *,
-    client: Client,
-    json_body: AuthenticationRequest,
+        *,
+        client: Client,
+        json_body: AuthenticationRequest,
 ) -> Response[Union[AuthenticationResponse, None]]:
     kwargs = _get_kwargs(
         client=client,
@@ -142,9 +140,9 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    *,
-    client: Client,
-    json_body: AuthenticationRequest,
+        *,
+        client: Client,
+        json_body: AuthenticationRequest,
 ) -> Optional[Union[AuthenticationResponse, None]]:
     """Used to retrieve all target segments for certain account id."""
 

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -72,8 +72,6 @@ def sync_detailed(
     return _build_response(response=response)
 
 
-
-
 def handle_http_result(response):
     # 408 request timeout
     # 425 too early
@@ -95,9 +93,9 @@ def handle_http_result(response):
 def _post_request(kwargs, max_auth_retries):
     retryer = Retrying(
         wait=wait_exponential(multiplier=1, min=4, max=10),
-        retry=(
-                retry_if_result(
-                    lambda response: response.status_code != 200) ),
+        retry=(retry_if_result(
+            lambda response: response.status_code != 200
+            and handle_http_result)),
         before_sleep=lambda retry_state: log.warning(
             f'SDK_AUTH_2002: Authentication attempt #'
             f'{retry_state.attempt_number} '

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -104,8 +104,6 @@ def handle_http_result(response):
     retry=(
             retry_if_result(lambda response: response.status_code != 200) and
             retry_if_result(handle_http_result)),
-    # before_sleep=lambda retry_state: log.warning(f"Attempt #{
-    # retry_state.outcome.result()}"),
     before_sleep=lambda retry_state: log.warning(
         f'Client authentication attempt #{retry_state.attempt_number} '
         f'got {retry_state.outcome.result()} Retrying...')

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -36,25 +36,8 @@ def _parse_response(
 ) -> Optional[Union[AuthenticationResponse, None]]:
     if response.status_code == 200:
         response_200 = AuthenticationResponse.from_dict(response.json())
-
-        return response_200
-    if response.status_code == 401:
-        response_401 = None
-
-        return response_401
-    if response.status_code == 403:
-        response_403 = None
-
-        return response_403
-    if response.status_code == 404:
-        response_404 = None
-
-        return response_404
-    if response.status_code == 500:
-        response_500 = None
-
-        return response_500
-    return None
+    else:
+        return None
 
 
 def _build_response(
@@ -93,9 +76,11 @@ def handle_http_result(response):
     # 504 gateway timeout
     #  -1 OpenAPI error (timeout etc.)
     code = response.status_code
-    if code in [403, 425, 429, 500, 502, 503, 504, -1]:
+    if code in [408, 425, 429, 500, 502, 503, 504, -1]:
         return True
     else:
+        log.error(f'Authentication failed with HTTP code #{code} and '
+                  'will not attempt to reconnect')
         return False
 
 

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -96,6 +96,22 @@ def sync(
     ).parsed
 
 
+def should_retry_http_code(code):
+    # 408 request timeout
+    # 425 too early
+    # 429 too many requests
+    # 500 internal server error
+    # 502 bad gateway
+    # 503 service unavailable
+    # 504 gateway timeout
+    #  -1 OpenAPI error (timeout etc)
+    if code == 408 | 425 | 429 | 500 | 502 | 503 | 504 | -1:
+        return True
+    else:
+        return False
+
+
+
 async def asyncio_detailed(
     *,
     client: Client,

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -73,15 +73,8 @@ def sync_detailed(
 
 
 def handle_http_result(response):
-    # 408 request timeout
-    # 425 too early
-    # 429 too many requests
-    # 500 internal server error
-    # 502 bad gateway
-    # 503 service unavailable
-    # 504 gateway timeout
     code = response.status_code
-    if code in [408, 425, 429, 500, 502, 503, 504]:
+    if code in {408, 425, 429, 500, 502, 503, 504}:
         return True
     else:
         log.error(

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -82,7 +82,7 @@ def sync_detailed(
     return _build_response(response=response)
 
 
-def should_retry_http_code(code):
+def should_retry_http_code(response):
     # 408 request timeout
     # 425 too early
     # 429 too many requests
@@ -91,7 +91,8 @@ def should_retry_http_code(code):
     # 503 service unavailable
     # 504 gateway timeout
     #  -1 OpenAPI error (timeout etc.)
-    if code == 408 | 425 | 429 | 500 | 502 | 503 | 504 | -1:
+    code = response.status_code
+    if code in [404, 425, 429, 500, 502, 503, 504, -1]:
         return True
     else:
         return False
@@ -99,10 +100,9 @@ def should_retry_http_code(code):
 
 @retry(stop_max_attempt_number=3, retry_on_result=should_retry_http_code)
 def _post_request(kwargs):
-    response = httpx.post(
+    return httpx.post(
         **kwargs,
     )
-    return response
 
 
 def sync(

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -37,7 +37,7 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = AuthenticationResponse.from_dict(response.json())
     else:
-        return None
+        raise Exception('Authentication failed on an unrecoverable error')
 
 
 def _build_response(

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -36,7 +36,6 @@ def _get_kwargs(
     }
 
 
-# TODO fix response for else condition
 def _parse_response(
         *, response: httpx.Response
 ) -> Optional[Union[AuthenticationResponse, None]]:

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -91,8 +91,7 @@ def handle_http_result(response):
     # 503 service unavailable
     # 504 gateway timeout
     #  -1 OpenAPI error (timeout etc.)
-    code = response.status_code
-    if code in [404, 425, 429, 500, 502, 503, 504, -1]:
+    if response.status_code in [404, 425, 429, 500, 502, 503, 504, -1]:
         return True
     else:
         return False

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -7,7 +7,7 @@ from featureflags.api.client import Client
 from featureflags.api.types import Response
 from featureflags.models.authentication_request import AuthenticationRequest
 from featureflags.models.authentication_response import AuthenticationResponse
-from tenacity import retry, retry_if_result, wait_exponential, \
+from tenacity import retry_if_result, wait_exponential, \
     stop_after_attempt, Retrying
 
 

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -83,7 +83,7 @@ def handle_http_result(response):
     # 503 service unavailable
     # 504 gateway timeout
     code = response.status_code
-    if code in [403, 425, 429, 500, 502, 503, 504]:
+    if code in [408, 425, 429, 500, 502, 503, 504]:
         return True
     else:
         log.error(f'Authentication failed with HTTP code #{code} and '

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -6,7 +6,7 @@ from featureflags.api.client import Client
 from featureflags.api.types import Response
 from featureflags.models.authentication_request import AuthenticationRequest
 from featureflags.models.authentication_response import AuthenticationResponse
-from tenacity import retry, retry_if_result
+from tenacity import retry, retry_if_result, wait_exponential
 
 
 def _get_kwargs(
@@ -98,6 +98,7 @@ def handle_http_result(response):
 
 
 @retry(
+    wait=wait_exponential(multiplier=1, min=4, max=10),
     retry=(
         retry_if_result(lambda response: response.status_code != 200) and
         retry_if_result(handle_http_result))

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -105,7 +105,7 @@ def handle_http_result(response):
             retry_if_result(lambda response: response.status_code != 200) and
             retry_if_result(handle_http_result)),
     before_sleep=lambda retry_state: log.warning(
-        f'Client authentication attempt #{retry_state.attempt_number} '
+        f'Authentication attempt #{retry_state.attempt_number} '
         f'got {retry_state.outcome.result()} Retrying...')
 )
 def _post_request(kwargs):

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -108,7 +108,7 @@ def handle_http_result(response):
     # retry_state.outcome.result()}"),
     before_sleep=lambda retry_state: log.warning(
         f'Client authentication attempt #{retry_state.attempt_number} '
-        f'received :{retry_state.outcome.result()} Retrying...')
+        f'got {retry_state.outcome.result()} Retrying...')
 )
 def _post_request(kwargs):
     return httpx.post(

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -74,7 +74,6 @@ def handle_http_result(response):
     # 502 bad gateway
     # 503 service unavailable
     # 504 gateway timeout
-    #  -1 OpenAPI error (timeout etc.)
     code = response.status_code
     if code in [408, 425, 429, 500, 502, 503, 504, -1]:
         return True

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -67,11 +67,11 @@ def sync_detailed(
         client=client,
         json_body=json_body,
     )
-
     max_auth_retries = client.get_max_auth_retries()
     response = _post_request(kwargs, max_auth_retries)
-
     return _build_response(response=response)
+
+
 
 
 def handle_http_result(response):

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -98,7 +98,6 @@ def handle_http_result(response):
         return False
 
 
-# @retry(stop_max_attempt_number=3, retry_on_result=handle_http_result)
 @retry(
     retry=(
         retry_if_result(lambda response: response.status_code != 200) and

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -8,7 +8,7 @@ from featureflags.api.types import Response
 from featureflags.models.authentication_request import AuthenticationRequest
 from featureflags.models.authentication_response import AuthenticationResponse
 from tenacity import retry_if_result, wait_exponential, \
-    stop_after_attempt, Retrying
+    stop_after_attempt, Retrying, retry_all
 
 
 class UnrecoverableAuthenticationException(Exception):
@@ -85,9 +85,8 @@ def handle_http_result(response):
 def _post_request(kwargs, max_auth_retries):
     retryer = Retrying(
         wait=wait_exponential(multiplier=1, min=4, max=10),
-        retry=(
-            retry_if_result(
-                lambda response: response.status_code != 404) and
+        retry=retry_all(
+            retry_if_result(lambda response: response.status_code != 200),
             retry_if_result(handle_http_result)
         ),
         before_sleep=lambda retry_state: log.warning(

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -78,7 +78,7 @@ def handle_http_result(response):
     # 503 service unavailable
     # 504 gateway timeout
     code = response.status_code
-    if code in [408, 425, 429, 500, 502, 503, 504]:
+    if code in [409, 425, 429, 500, 502, 503, 504]:
         return True
     else:
         log.error(f'Authentication failed with HTTP code #{code} and '
@@ -96,7 +96,8 @@ def _post_request(kwargs, max_auth_retries):
         before_sleep=lambda retry_state: log.warning(
             f'Authentication attempt #{retry_state.attempt_number} '
             f'got {retry_state.outcome.result()} Retrying...'),
-        stop=stop_after_attempt(max_auth_retries))
+        stop=stop_after_attempt(max_auth_retries),
+    )
     return retryer(httpx.post, **kwargs)
 
 

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -87,8 +87,8 @@ def _post_request(kwargs, max_auth_retries):
         wait=wait_exponential(multiplier=1, min=4, max=10),
         retry=(
             retry_if_result(
-                lambda response: response.status_code != 404)
-            and retry_if_result(handle_http_result)
+                lambda response: response.status_code != 404) and
+            retry_if_result(handle_http_result)
         ),
         before_sleep=lambda retry_state: log.warning(
             f'SDK_AUTH_2002: Authentication attempt #'

--- a/featureflags/api/default/authenticate.py
+++ b/featureflags/api/default/authenticate.py
@@ -41,7 +41,7 @@ def _parse_response(
         *, response: httpx.Response
 ) -> Optional[Union[AuthenticationResponse, None]]:
     if response.status_code == 200:
-        response_200 = AuthenticationResponse.from_dict(response.json())
+        return AuthenticationResponse.from_dict(response.json())
     else:
         raise UnrecoverableAuthenticationException(
             f'Authentication failed on an unrecoverable error: {response}')
@@ -86,8 +86,9 @@ def handle_http_result(response):
     if code in [408, 425, 429, 500, 502, 503, 504]:
         return True
     else:
-        log.error(f'Authentication failed with HTTP code #{code} and '
-                  'will not attempt to reconnect')
+        log.error(
+            f'SDK_AUTH_2001: Authentication failed with HTTP code #{code} and '
+            'will not attempt to reconnect')
         return False
 
 
@@ -96,10 +97,10 @@ def _post_request(kwargs, max_auth_retries):
         wait=wait_exponential(multiplier=1, min=4, max=10),
         retry=(
                 retry_if_result(
-                    lambda response: response.status_code != 200) and
-                retry_if_result(handle_http_result)),
+                    lambda response: response.status_code != 200) ),
         before_sleep=lambda retry_state: log.warning(
-            f'Authentication attempt #{retry_state.attempt_number} '
+            f'SDK_AUTH_2002: Authentication attempt #'
+            f'{retry_state.attempt_number} '
             f'got {retry_state.outcome.result()} Retrying...'),
         stop=stop_after_attempt(max_auth_retries),
     )

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -3,7 +3,6 @@
 import threading
 from typing import Any, Callable, Dict, Optional
 
-import tenacity
 from jwt import decode
 
 import featureflags.api.default.authenticate

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -101,9 +101,15 @@ class CfClient(object):
             log.error(
                 "Authentication failed and max retries have been exceeded - "
                 "defaults will be served.")
+            # Mark the client as initialized in case wait_for_initialization
+            # is called. The SDK has already logged that authentication
+            # failed and defaults will be returned.
+            self._initialized.set()
         except UnrecoverableAuthenticationException:
             log.error(
                 "Authentication failed - defaults will be served.")
+            # Same again, just mark the client as initailized.
+            self._initialized.set()
 
     def wait_for_initialization(self):
         log.debug("Waiting for initialization to finish")

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -143,7 +143,8 @@ class CfClient(object):
             token=self._auth_token,
             params={
                 'cluster': self._cluster
-            }
+            },
+            max_auth_retries=self._config.max_auth_retries
         )
         # Additional headers used to track usage
         additional_headers = {

--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -3,9 +3,9 @@
 import threading
 from typing import Any, Callable, Dict, Optional
 
+from tenacity import RetryError
 from jwt import decode
 
-import featureflags.api.default.authenticate
 from featureflags.analytics import AnalyticsService
 from featureflags.evaluations.evaluator import Evaluator
 from featureflags.repository import Repository
@@ -96,7 +96,7 @@ class CfClient(object):
                     environment=self._environment_id
                 )
 
-        except tenacity.RetryError:
+        except RetryError:
             log.error(
                 "Authentication failed and max retries have been exceeded - "
                 "defaults will be served.")

--- a/featureflags/config.py
+++ b/featureflags/config.py
@@ -25,7 +25,8 @@ class Config(object):
             cache: Cache = None,
             store: object = None,
             enable_stream: bool = True,
-            enable_analytics: bool = True
+            enable_analytics: bool = True,
+            max_auth_retries: int = 10
     ):
         self.base_url = base_url
         self.events_url = events_url
@@ -38,6 +39,7 @@ class Config(object):
         self.store = store
         self.enable_stream = enable_stream
         self.enable_analytics = enable_analytics
+        self.max_auth_retries = max_auth_retries
 
 
 default_config = Config()
@@ -74,5 +76,12 @@ def with_analytics_enabled(value: bool) -> Callable:
 def with_pull_interval(value: int) -> Callable:
     def func(config: Config) -> None:
         config.pull_interval = value
+
+    return func
+
+
+def with_max_auth_retries(value: int) -> Callable:
+    def func(config: Config) -> None:
+        config.max_auth_retries = value
 
     return func


### PR DESCRIPTION
# What
The SDK did not have a retry mechanism for "retryable" HTTP errors when authenticating. It also had unhandled exceptions in these cases and the SDK would crash. 
This PR adds 

1. Retry mechanism for certain HTTP codes with logging which adheres to the SDK codes wiki. Adds a new optional config option `with_max_auth_retries` with the default being 10 if not specified.
3. If authentication fails: 
   - then the SDK will not start any other post-authentication services like polling or streaming. 
   - The SDK will only serve default values with log messaging adhering to SDK codes wiki

# Testing 
No unit tests exist for the API layer at all, so instead of taking another day or two to create them, I performed manual testing

1. Happy path - SDK gets 200.
2. Retryable error path - SDK retries on correct codes and authenticates
4. Unhappy path - SDK gets an unretryable code (e.g. 403) and does not attempt to retry. It will only serve defaults and post authentication services not started. 
5. `wait_for_intiailzation` - if this is called, and authentication fails either on max exceeded retries of if there is an unretryable error, then we mark the SDK as initialized so unblock the call. But - the SDK will already log that auth failed and defaults to be returned.