### PR TITLE
1.1.14 release prep

### DIFF
--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.1.13'
+__version__ = '1.1.14'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.13
+current_version = 1.1.14
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/harness/ff-python-server-sdk",
-    version='1.1.13',
+    version='1.1.14',
     zip_safe=False,
 )


### PR DESCRIPTION
What
The previous release 1.1.13 has been deleted from Pypi due to it being broken. Pypi does not let you override a release, so while I have deleted 1.1.13 from Pypi, I need to publish a new version with the fix.