### PR TITLE
FFM-8231 Temporary limit of TargetMetrics size

### DIFF
--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.1.15'
+__version__ = '1.1.16'

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -63,6 +63,7 @@ class AnalyticsService(object):
         self._environment = environment
         self._data: Dict[str, AnalyticsEvent] = {}
         self._target_data: Dict[str, MetricTargetData] = {}
+        self.max_target_data_exceeded = False
 
         self._running = False
         self._runner = Thread(target=self._sync)
@@ -95,8 +96,12 @@ class AnalyticsService(object):
             # should get registered eventually on subsequent evaluations.
             # We want to eventually use a batching solution
             # to avoid this.
-            if len(self._target_data) >= 50000:
-                info_metrics_target_exceeded()
+            max_target_size = 50000
+            if len(self._target_data) >= max_target_size:
+                # Only log the info code once per interval
+                if not self.max_target_data_exceeded:
+                    info_metrics_target_exceeded()
+                    self.max_target_data_exceeded = True
                 return
 
             # Store unique targets. If the target already exists

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -90,7 +90,7 @@ class AnalyticsService(object):
                 self._data[unique_evaluation_key] = event
 
             # Temporary workaround for FFM-8231 - limit max size of target
-            # metrics to 40k, which ff-server can process in around
+            # metrics to 50k, which ff-server can process in around
             # 15 seconds. This possibly prevent some targets from getting
             # registered and showing in the UI, but in theory, they
             # should get registered eventually on subsequent evaluations.

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -95,6 +95,7 @@ class AnalyticsService(object):
             # We want to eventually use a batching solution
             # to avoid this.
             if len(self._target_data) >= 50000:
+
                 return
 
             # Store unique targets. If the target already exists

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -191,6 +191,7 @@ class AnalyticsService(object):
         finally:
             self._data = {}
             self._target_data = {}
+            self.max_target_data_exceeded = False
             self._lock.release()
 
         body: Metrics = Metrics(target_data=target_data,

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -89,26 +89,28 @@ class AnalyticsService(object):
                 event.count = 1
                 self._data[unique_evaluation_key] = event
 
-            # Temporary workaround for FFM-8231 - limit max size of target
-            # metrics to 50k, which ff-server can process in around
-            # 18 seconds. This possibly prevent some targets from getting
-            # registered and showing in the UI, but in theory, they
-            # should get registered eventually on subsequent evaluations.
-            # We want to eventually use a batching solution
-            # to avoid this.
-            max_target_size = 50000
-            if len(self._target_data) >= max_target_size:
-                # Only log the info code once per interval
-                if not self.max_target_data_exceeded:
-                    info_metrics_target_exceeded()
-                    self.max_target_data_exceeded = True
-                return
-
             # Store unique targets. If the target already exists
             # just ignore it.
             if event.target is not None and not event.target.anonymous:
                 unique_target_key = self.get_target_key(event)
                 if unique_target_key not in self._target_data:
+                    # Temporary workaround for FFM-8231 - limit max size of
+                    # target
+                    # metrics to 50k, which ff-server can process in around
+                    # 18 seconds. This possibly prevent some targets from
+                    # getting
+                    # registered and showing in the UI, but in theory, they
+                    # should get registered eventually on subsequent
+                    # evaluations.
+                    # We want to eventually use a batching solution
+                    # to avoid this.
+                    max_target_size = 50000
+                    if len(self._target_data) >= max_target_size:
+                        # Only log the info code once per interval
+                        if not self.max_target_data_exceeded:
+                            info_metrics_target_exceeded()
+                            self.max_target_data_exceeded = True
+                        return
                     target_name = event.target.name
                     # If the target has no name use the identifier
                     if not target_name:

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -19,7 +19,8 @@ from .models.metrics_data import MetricsData
 from .models.target_data import TargetData
 from .models.unset import Unset
 from .sdk_logging_codes import info_metrics_thread_started, \
-    info_metrics_success, warn_post_metrics_failed, info_metrics_thread_existed
+    info_metrics_success, warn_post_metrics_failed, \
+    info_metrics_thread_existed, info_metrics_target_exceeded
 from .util import log
 
 FF_METRIC_TYPE = 'FFMETRICS'
@@ -95,7 +96,7 @@ class AnalyticsService(object):
             # We want to eventually use a batching solution
             # to avoid this.
             if len(self._target_data) >= 50000:
-
+                info_metrics_target_exceeded()
                 return
 
             # Store unique targets. If the target already exists

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -91,7 +91,7 @@ class AnalyticsService(object):
 
             # Temporary workaround for FFM-8231 - limit max size of target
             # metrics to 50k, which ff-server can process in around
-            # 15 seconds. This possibly prevent some targets from getting
+            # 18 seconds. This possibly prevent some targets from getting
             # registered and showing in the UI, but in theory, they
             # should get registered eventually on subsequent evaluations.
             # We want to eventually use a batching solution

--- a/featureflags/api/client.py
+++ b/featureflags/api/client.py
@@ -12,7 +12,7 @@ class Client:
     params: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
     cookies: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
     headers: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
-    timeout: float = attr.ib(5.0, kw_only=True)
+    timeout: float = attr.ib(30.0, kw_only=True)
     max_auth_retries: int
 
     def get_headers(self) -> Dict[str, str]:

--- a/featureflags/sdk_logging_codes.py
+++ b/featureflags/sdk_logging_codes.py
@@ -34,6 +34,8 @@ def get_sdk_code_message(key):
         7001: "Metrics thread exited",
         7002: "Posting metrics failed, reason:",
         7003: "Metrics posted successfully",
+        7004: "Target metrics exceeded max size, remaining targets for this"
+              "analytics interval will not be sent in metrics payload",
     }
     if key in sdk_codes:
         return sdk_codes[key]
@@ -97,6 +99,10 @@ def info_metrics_thread_started(interval):
 
 def info_metrics_success():
     log.info(sdk_err_msg(7003))
+
+
+def info_metrics_target_exceeded():
+    log.info(sdk_err_msg(7004))
 
 
 def info_metrics_thread_existed():

--- a/featureflags/sdk_logging_codes.py
+++ b/featureflags/sdk_logging_codes.py
@@ -34,8 +34,8 @@ def get_sdk_code_message(key):
         7001: "Metrics thread exited",
         7002: "Posting metrics failed, reason:",
         7003: "Metrics posted successfully",
-        7004: "Target metrics exceeded max size, remaining targets for this"
-              "analytics interval will not be sent in metrics payload",
+        7004: "Target metrics exceeded max size, remaining targets for this "
+              "analytics interval will not be sent",
     }
     if key in sdk_codes:
         return sdk_codes[key]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.15
+current_version = 1.1.16
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "httpx>=0.23.0",
+    "httpx>=0.24.1",
     "pyjwt>=2.4.0",
     "attrs>=21.2.0",
     "mmh3>=3.0.0",
@@ -57,6 +57,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/harness/ff-python-server-sdk",
-    version='1.1.15',
+    version='1.1.16',
     zip_safe=False,
 )

--- a/tests/unit/test_sdk_logging_codes.py
+++ b/tests/unit/test_sdk_logging_codes.py
@@ -17,6 +17,7 @@ def test_logs_dont_raise_exception():
     sdk_codes.info_metrics_thread_started(10)
     sdk_codes.info_metrics_thread_existed()
     sdk_codes.info_metrics_success()
+    sdk_codes.info_metrics_target_exceeded()
     sdk_codes.warn_auth_failed_srv_defaults()
     sdk_codes.warn_failed_init_auth_error()
     sdk_codes.warn_auth_failed_exceed_retries()


### PR DESCRIPTION
# What
This is a temporary solution for FFM-8231. We are seeing `read_timeout` errors in the SDK for metrics requests. This is due to huge numbers of targets being sent in the metrics payload. see a breakdown of response times:

20k target: 8 seconds
50K targets: 18 seconds
55K targets: 28 seconds

This PR addresses the number of Targets that we can send to the metrics service in each metrics interval. If we use 30 seconds as the maximum time we allow SDKs to wait on a response for a metrics request, then that limit is reached if we send 60K targets. To prevent read_timeouts, this PR increases the `read_timeout` to 30 seconds and sets the Target limit to 50000 which should process and yield a `200` response in 18 seconds, which gives as 12 second margin of error.

The SDK will log code `7004` if the target number is exceeded, informing the user.

# Testing
Manual - sent over 60K targets but only 50K targets get sent in the payload. 

Caveat
:while`Evaluation` metrics are unaffected, legitimately new targets might not appear in the UI immediately - but should eventually on subsequent intervals.