### PR TITLE
FFM-8544 Reorganise streaming logs

### DIFF
--- a/featureflags/__init__.py
+++ b/featureflags/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Enver Bisevac"""
 __email__ = "enver.bisevac@harness.io"
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -256,9 +256,10 @@ class AnalyticsService(object):
 
                 # Log any error codes
                 for unique_code, count in unique_responses_codes.items():
-                    if response.status_code >= 400:
+                    if unique_code >= 400:
                         warn_post_metrics_target_batch_failed(
                             f'{count} batches received code {unique_code}')
+                        continue
                     info_metrics_target_batch_success(
                         f'{count} batches successful')
 

--- a/featureflags/analytics.py
+++ b/featureflags/analytics.py
@@ -206,7 +206,6 @@ class AnalyticsService(object):
                         unique_target)
                 target_data_batch_index += 1
 
-
         finally:
             self._data = {}
             self._target_data_batches = [{}]
@@ -263,11 +262,9 @@ class AnalyticsService(object):
                     info_metrics_target_batch_success(
                         f'{count} batches successful')
 
-
             info_metrics_success()
         except httpx.RequestError as ex:
             warn_post_metrics_failed(ex)
-
 
     def process_target_data_batch(self, target_data_batch):
         batch_request_body: Metrics = Metrics(

--- a/featureflags/polling.py
+++ b/featureflags/polling.py
@@ -91,7 +91,6 @@ class PollingProcessor(Thread):
         self.__running = False
         info_polling_stopped("Client was closed")
 
-
     def retrieve_flags_and_segments(self):
         t1 = Thread(target=self.__retrieve_segments)
         t2 = Thread(target=self.__retrieve_flags)

--- a/featureflags/sdk_logging_codes.py
+++ b/featureflags/sdk_logging_codes.py
@@ -27,6 +27,7 @@ def get_sdk_code_message(key):
         5002: "SSE event received: ",
         5003: "SSE retrying to connect in",
         5004: "SSE stopped",
+        5005: "Stream is still retrying after 5 retries: ",
         # SDK_EVAL_6xxx - these are hardcoded in `variation.py` as they
         # are more complex
         # SDK_METRICS_7xxx
@@ -143,6 +144,10 @@ def warn_stream_disconnected(reason):
 
 def warn_stream_retrying(seconds):
     log.warning(sdk_err_msg(5003, seconds))
+
+
+def warn_stream_retrying_long_duration(seconds):
+    log.warning(sdk_err_msg(5005, f'{seconds} seconds'))
 
 
 def warn_post_metrics_failed(reason):

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -123,7 +123,6 @@ class SSEClient(object):
                 # if we have half a message we should throw it out.
                 head, sep, _ = self.buf.rpartition("\n")
                 self.buf = head + sep
-
                 continue
 
         # Split the complete event (up to the end_of_field) into event_string,

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -111,18 +111,13 @@ class SSEClient(object):
                     raise EOFError()
                 self.buf += self.decoder.decode(next_chunk)
 
-            except (StopIteration, requests.RequestException, EOFError) as e:
-                if isinstance(e, StopIteration):
-                    log.debug("Error when iterating through stream messages, "
-                              "attempting to resume")
+            except (StopIteration, EOFError) as e:
 
                 if isinstance(e, EOFError):
-                    log.debug("Received unexpected EOF from stream, "
-                              "attempting to reconnect")
+                    log.debug("Recieved empty chunk of data from stream, "
+                              "reconnecting")
 
-                if isinstance(e, requests.RequestException):
-                    log.debug("Error encountered in stream, "
-                              "attempting to reconnect: %s", e)
+                log.debug("Streaming stopped")
 
                 # Check if reconnect error flag is set and the elapsed time exceeds a certain threshold (e.g., 10 seconds)
                 if self.reconnect_error and self.reconnect_timer > 10:

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -21,13 +21,13 @@ end_of_field: Pattern[str] = re.compile(r"\r\n\r\n|\r\r|\n\n")
 
 class SSEClient(object):
     def __init__(
-        self,
-        url: str,
-        last_id: str = None,
-        retry: int = 3000,
-        session: Any = None,
-        chunk_size: int = 1024,
-        **kwargs: Dict[str, Any]
+            self,
+            url: str,
+            last_id: str = None,
+            retry: int = 3000,
+            session: Any = None,
+            chunk_size: int = 1024,
+            **kwargs: Dict[str, Any]
     ):
         self.url = url
         self.last_id = last_id
@@ -56,9 +56,6 @@ class SSEClient(object):
         self.buf: str = ""
 
         self._connect()
-        self.reconnect_timer = 0
-        self.reconnect_error = False
-
 
     def _connect(self):
         if self.last_id:
@@ -81,9 +78,9 @@ class SSEClient(object):
         def generate():
             while True:
                 if (
-                    hasattr(self.resp.raw, "_fp")
-                    and hasattr(self.resp.raw._fp, "fp")
-                    and hasattr(self.resp.raw._fp.fp, "read1")
+                        hasattr(self.resp.raw, "_fp")
+                        and hasattr(self.resp.raw._fp, "fp")
+                        and hasattr(self.resp.raw._fp.fp, "read1")
                 ):
                     chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
                 else:
@@ -117,11 +114,7 @@ class SSEClient(object):
                     log.debug("Recieved empty chunk of data from stream, "
                               "reconnecting")
 
-                log.debug("Streaming stopped")
-
-                # Check if reconnect error flag is set and the elapsed time exceeds a certain threshold (e.g., 10 seconds)
-                if self.reconnect_error and self.reconnect_timer > 10:
-                    log.error("Failed to reconnect after a certain period")
+                log.debug("Streaming stopped abruptly, reconnecting")
 
                 time.sleep(self.retry / 1000.0)
                 self._connect()
@@ -131,10 +124,6 @@ class SSEClient(object):
                 head, sep, _ = self.buf.rpartition("\n")
                 self.buf = head + sep
 
-                if self.reconnect_error:
-                    self.reconnect_timer += self.retry / 1000.0
-                else:
-                    self.reconnect_error = True
                 continue
 
         # Split the complete event (up to the end_of_field) into event_string,
@@ -161,17 +150,16 @@ class SSEClient(object):
 
 
 class Event(object):
-
     sse_line_pattern: Pattern[str] = re.compile(
         "(?P<name>[^:]*):?( ?(?P<value>.*))?"
     )
 
     def __init__(
-        self,
-        data: str = "",
-        event: str = "message",
-        id: Optional[str] = None,
-        retry: Optional[int] = None,
+            self,
+            data: str = "",
+            event: str = "message",
+            id: Optional[str] = None,
+            retry: Optional[int] = None,
     ):
         self.data = data
         self.event = event

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -124,7 +124,6 @@ class SSEClient(object):
                 head, sep, _ = self.buf.rpartition("\n")
                 self.buf = head + sep
 
-
                 continue
 
         # Split the complete event (up to the end_of_field) into event_string,

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -142,10 +142,6 @@ class SSEClient(object):
         if msg.id:
             self.last_id = msg.id
 
-        # If we've encountered an error and had to reconnect, mark it
-        # as resolved by resetting the reconnect_error flag to False
-        self.reconnect_error = False
-
         return msg
 
 

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -21,13 +21,13 @@ end_of_field: Pattern[str] = re.compile(r"\r\n\r\n|\r\r|\n\n")
 
 class SSEClient(object):
     def __init__(
-            self,
-            url: str,
-            last_id: str = None,
-            retry: int = 3000,
-            session: Any = None,
-            chunk_size: int = 1024,
-            **kwargs: Dict[str, Any]
+        self,
+        url: str,
+        last_id: str = None,
+        retry: int = 3000,
+        session: Any = None,
+        chunk_size: int = 1024,
+        **kwargs: Dict[str, Any]
     ):
         self.url = url
         self.last_id = last_id
@@ -57,6 +57,8 @@ class SSEClient(object):
 
         self._connect()
 
+
+
     def _connect(self):
         if self.last_id:
             self.requests_kwargs["headers"]["Last-Event-ID"] = self.last_id
@@ -78,9 +80,9 @@ class SSEClient(object):
         def generate():
             while True:
                 if (
-                        hasattr(self.resp.raw, "_fp")
-                        and hasattr(self.resp.raw._fp, "fp")
-                        and hasattr(self.resp.raw._fp.fp, "read1")
+                    hasattr(self.resp.raw, "_fp")
+                    and hasattr(self.resp.raw._fp, "fp")
+                    and hasattr(self.resp.raw._fp.fp, "read1")
                 ):
                     chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
                 else:
@@ -124,6 +126,7 @@ class SSEClient(object):
                 head, sep, _ = self.buf.rpartition("\n")
                 self.buf = head + sep
 
+
                 continue
 
         # Split the complete event (up to the end_of_field) into event_string,
@@ -150,16 +153,17 @@ class SSEClient(object):
 
 
 class Event(object):
+
     sse_line_pattern: Pattern[str] = re.compile(
         "(?P<name>[^:]*):?( ?(?P<value>.*))?"
     )
 
     def __init__(
-            self,
-            data: str = "",
-            event: str = "message",
-            id: Optional[str] = None,
-            retry: Optional[int] = None,
+        self,
+        data: str = "",
+        event: str = "message",
+        id: Optional[str] = None,
+        retry: Optional[int] = None,
     ):
         self.data = data
         self.event = event

--- a/featureflags/sse_client.py
+++ b/featureflags/sse_client.py
@@ -57,8 +57,6 @@ class SSEClient(object):
 
         self._connect()
 
-
-
     def _connect(self):
         if self.last_id:
             self.requests_kwargs["headers"]["Last-Event-ID"] = self.last_id

--- a/featureflags/streaming.py
+++ b/featureflags/streaming.py
@@ -42,7 +42,6 @@ class StreamProcessor(Thread):
         self._stream_url = f'{config.base_url}/stream?cluster={cluster}'
         self._repository = repository
         self.reconnect_timer = 0
-        self.reconnect_error = False
 
     def run(self):
         log.info("Starting StreamingProcessor connecting to uri: " +

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/harness/ff-python-server-sdk",
-    version='1.2.0',
+    version='1.2.1',
     zip_safe=False,
 )

--- a/tests/unit/test_sdk_logging_codes.py
+++ b/tests/unit/test_sdk_logging_codes.py
@@ -25,6 +25,7 @@ def test_logs_dont_raise_exception():
     sdk_codes.warn_auth_retying(1, "some error")
     sdk_codes.warn_stream_disconnected("example reason")
     sdk_codes.warn_stream_retrying(5)
+    sdk_codes.warn_stream_retrying_long_duration(5)
     sdk_codes.warn_post_metrics_failed("example reason")
     sdk_codes.warn_post_metrics_target_batch_failed("example reason")
     sdk_codes.warn_default_variation_served("identifier", target, "default")


### PR DESCRIPTION
# What
- Removes the responsiblity for logging streaming errors from the `sse_client` module to the `streaming` module. 
- Logs a warning if the SDK is still connecting after four attempts.

# Why
The sse_client catches iteration errors and potential empty chunk errors, which will happen frequently for any transitive network issues. We were previously logging these as errors which was misleading. 

# Testing
Manual disconnect/reconnect
