### PR TITLE
FFM-8544 Only include accountID if it is present in the JWT, i.e., th…

### DIFF
--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -166,8 +166,10 @@ class CfClient(object):
         additional_headers = {
             "User-Agent": "PythonSDK/" + VERSION,
             "Harness-SDK-Info": f'Python {VERSION} Server',
-            "Harness-EnvironmentID": self._environment_id,
-            "Harness-AccountID": decoded["accountID"]}
+            "Harness-EnvironmentID": self._environment_id}
+        # At present the FF Relay Proxy does not send the accountID claim
+        if "accountID" in decoded:
+            additional_headers["Harness-AccountID"] = decoded["accountID"]
         self._client = self._client.with_headers(additional_headers)
 
     def bool_variation(self, identifier: str, target: Target,


### PR DESCRIPTION
What
When the ff relay proxy is being used, the accountID is not currently present as a claim in the auth JWT. This fix adds a check to see if the accountID is present before including it in the additional headers. Note: we still want to include the other additional headers, as they are still useful.

Why
Users running the relay proxy would get a runtime error as the accountID is not present there.

Testing
Tested on latest relay proxy version, and without the proxy