### PR TITLE
MAINT Patch setuptools CVE

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ twine==3.4.1
 pytest>=7
 pytest-runner==5.1
 pytest-mock==3.6.1
-setuptools~=65.5.1
+setuptools~=70.0.0
 httpx~=0.24.1
 attrs==23.2.0
 


### PR DESCRIPTION
# What
Bumps setuptools to ~=70.0.0

# Why
CVE ID
CVE-2024-6345

*This is a dev dependency and is not shipped to user code*