### PR TITLE
{client,config}: allow passing through additional httpx arguments

### DIFF
--- a/featureflags/client.py
+++ b/featureflags/client.py
@@ -177,7 +177,7 @@ class CfClient(object):
             verify = self._config.tls_trusted_cas_file
 
         client = Client(base_url=self._config.base_url, verify_ssl=verify,
-                        raise_on_unexpected_status=True)
+                        raise_on_unexpected_status=True, httpx_args=self._config.httpx_args)
         body = AuthenticationRequest(api_key=self._sdk_key)
         response = retryable_authenticate(client=client, body=body).parsed
         self._auth_token = response.auth_token
@@ -206,7 +206,8 @@ class CfClient(object):
         client = AuthenticatedClient(
             base_url=url,
             token=token,
-            verify_ssl=verify
+            verify_ssl=verify,
+            httpx_args=self._config.httpx_args,
         )
         # Additional headers used to track usage
         additional_headers = {

--- a/featureflags/config.py
+++ b/featureflags/config.py
@@ -1,7 +1,7 @@
 """Configuration is a base class that has default values that you can change
 during the instance of the client class"""
 
-from typing import Callable
+from typing import Any, Callable, Dict
 
 from .interface import Cache
 from .lru_cache import LRUCache
@@ -28,7 +28,8 @@ class Config(object):
             enable_stream: bool = True,
             enable_analytics: bool = True,
             max_auth_retries: int = 10,
-            tls_trusted_cas_file: str = None
+            tls_trusted_cas_file: str = None,
+            httpx_args: Dict[str, Any] = None,
     ):
         self.base_url = base_url
         self.events_url = events_url
@@ -49,6 +50,9 @@ class Config(object):
         self.enable_analytics = enable_analytics
         self.max_auth_retries = max_auth_retries
         self.tls_trusted_cas_file = tls_trusted_cas_file
+        self.httpx_args = httpx_args
+        if self.httpx_args is None:
+            self.httpx_args = {}
 
 
 default_config = Config()
@@ -104,5 +108,12 @@ def with_tls_trusted_cas_file(value: str) -> Callable:
     """
     def func(config: Config) -> None:
         config.tls_trusted_cas_file = value
+
+    return func
+
+
+def with_httpx_args(args: Dict[str, Any]) -> Callable:
+    def func(config: Config) -> None:
+        config.httpx_args.update(args)
 
     return func


### PR DESCRIPTION
Does what it says on the tin.

Adds a `httpx_args` dict to `Config`, and a `with_httpx_args()` helper, which if specified multiple times will update the set of existing arguments. This is passed to the `Client` and `AuthenticatedClient` constructors.

Use case - using a HTTP proxy, e.g. `httpx_args={'proxy': 'http://my-proxy:8080'}`.
