### PR TITLE
fix: [FFM-12349]: fix bool equals clause

### DIFF
--- a/featureflags/evaluations/evaluator.py
+++ b/featureflags/evaluations/evaluator.py
@@ -214,29 +214,37 @@ class Evaluator(object):
         operator = clause.op.lower()
         type = target.get_type(clause.attribute)
 
-        if type is None:
-            if operator == SEGMENT_MATCH_OPERATOR.lower():
-                log.debug("Clause operator is %s, evaluate on segment",
-                          operator)
-                return self._check_target_in_segment(clause.values, target)
-            log.debug("Attribute type %s is none return false", type)
-            return False
-        log.debug("evaluate clause with object %s operator %s and value %s",
-                  type, operator.upper(), clause.values)
-        if operator == IN_OPERATOR.lower():
-            return type.in_list(clause.values)
-        if operator == EQUAL_OPERATOR.lower():
-            return type.equal(clause.values)
-        if operator == GT_OPERATOR.lower():
-            return type.greater_than(clause.values)
-        if operator == STARTS_WITH_OPERATOR.lower():
-            return type.starts_with(clause.values)
-        if operator == ENDS_WITH_OPERATOR.lower():
-            return type.ends_with(clause.values)
-        if operator == CONTAINS_OPERATOR.lower():
-            return type.contains(clause.values)
-        if operator == EQUAL_SENSITIVE_OPERATOR.lower():
-            return type.equal_sensitive(clause.values)
+        try:
+            if type is None:
+                if operator == SEGMENT_MATCH_OPERATOR.lower():
+                    log.debug("Clause operator is %s, evaluate on segment",
+                              operator)
+                    return self._check_target_in_segment(clause.values, target)
+                log.debug("Attribute type %s is none return false", type)
+                return False
+            log.debug("evaluate clause with object %s "
+                      "operator %s and value %s",
+                      type, operator.upper(), clause.values)
+            if operator == IN_OPERATOR.lower():
+                return type.in_list(clause.values)
+            if operator == EQUAL_OPERATOR.lower():
+                return type.equal(clause.values)
+            if operator == GT_OPERATOR.lower():
+                return type.greater_than(clause.values)
+            if operator == STARTS_WITH_OPERATOR.lower():
+                return type.starts_with(clause.values)
+            if operator == ENDS_WITH_OPERATOR.lower():
+                return type.ends_with(clause.values)
+            if operator == CONTAINS_OPERATOR.lower():
+                return type.contains(clause.values)
+            if operator == EQUAL_SENSITIVE_OPERATOR.lower():
+                return type.equal_sensitive(clause.values)
+        except ValueError:
+            log.debug("couldn't convert %s to type %s", clause.values, type)
+        except Exception as e:
+            log.warning("exception processing clause: "
+                        "values: %s, type: %s, "
+                        "error: %s", clause.values, type, e)
         # unknown operation
         return False
 

--- a/featureflags/ftypes/boolean.py
+++ b/featureflags/ftypes/boolean.py
@@ -3,7 +3,7 @@ import typing
 import attr
 
 from .interface import Interface
-from .utils import get_value
+from .utils import get_bool_value
 
 
 @attr.s(auto_attribs=True)
@@ -27,7 +27,7 @@ class Boolean(Interface):
         return False
 
     def equal(self, value: typing.Any) -> bool:
-        _value = get_value(value)
+        _value = get_bool_value(value)
         return self.value is _value
 
     def greater_than(self, value: typing.Any) -> bool:

--- a/featureflags/ftypes/utils.py
+++ b/featureflags/ftypes/utils.py
@@ -20,3 +20,6 @@ def get_int_value(value: typing.List[typing.Any]) -> int:
 
 def get_float_value(value: typing.List[typing.Any]) -> float:
     return float(get_value(value))
+
+def get_bool_value(value: typing.List[typing.Any]) -> int:
+    return bool(get_value(value))

--- a/tests/unit/test_boolean.py
+++ b/tests/unit/test_boolean.py
@@ -4,7 +4,7 @@ from featureflags.ftypes.boolean import Boolean
 def test_equal(mocker):
     input = [True, False]
 
-    m = mocker.patch("featureflags.ftypes.boolean.get_value",
+    m = mocker.patch("featureflags.ftypes.boolean.get_bool_value",
                      return_value=True)
     boolean = Boolean(value=True)
 

--- a/tests/unit/test_integer.py
+++ b/tests/unit/test_integer.py
@@ -12,10 +12,15 @@ from featureflags.ftypes.integer import Integer
         ("", [], None, "contains", False),
         ("", [], None, "equal_sensitive", False),
         (1, 1, 1, "equal", True),
+        (2, 2, 1, "equal", False),
         (2, 1, 1, "greater_than", True),
+        (1, 1, 2, "greater_than", False),
         (2, 1, 2, "greater_than_equal", True),
+        (1, 1, 2, "greater_than_equal", False),
         (1, 1, 2, "less_than", True),
+        (2, 1, 2, "less_than", False),
         (1, 1, 2, "less_than_equal", True),
+        (2, 2, 1, "less_than_equal", False),
     ],
 )
 def test_type_methods(mocker, arg, input, mocked, method, expected):

--- a/tests/unit/test_number.py
+++ b/tests/unit/test_number.py
@@ -11,11 +11,16 @@ from featureflags.ftypes.number import Number
         ("", [], None, "match", False),
         ("", [], None, "contains", False),
         ("", [], None, "equal_sensitive", False),
+        (1.5, 1.5, 1.1, "equal", False),
         (1.1, 1.1, 1.1, "equal", True),
         (2.0, 1.0, 1.0, "greater_than", True),
+        (1.0, 1.0, 2.0, "greater_than", False),
         (2.0, 1.0, 2.0, "greater_than_equal", True),
+        (1.0, 1.0, 2.0, "greater_than_equal", False),
         (1.0, 1.0, 2.0, "less_than", True),
+        (2.0, 2.0, 1.0, "less_than", False),
         (1.1, 1.1, 2.0, "less_than_equal", True),
+        (2.0, 2.0, 1.0, "less_than_equal", False),
     ],
 )
 def test_type_methods(mocker, arg, input, mocked, method, expected):


### PR DESCRIPTION
**Changes**

- Correctly cast string to boolean when attempting to evaluate a boolean equals clause e.g. target has attribute `premium: True` and we're attempting to check if that target belongs to a group with a rule of `premium equals true`
- Handle errors casting values. Previously if a target had an attribute of type `integer/number/whatever` we would assume the matching target group attribute could be successfully cast to this type, failure to do so would result in a runtime error. Added error handling to log and continue if this issue occurs in future. 